### PR TITLE
Add OSC haptics support

### DIFF
--- a/AxSlime/AxSlime.csproj
+++ b/AxSlime/AxSlime.csproj
@@ -10,10 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CSharpier.MsBuild" Version="0.27.2">
+    <PackageReference Include="CSharpier.MsBuild" Version="0.27.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="LucHeart.CoreOSC" Version="1.2.1" />
   </ItemGroup>
 
 </Project>

--- a/AxSlime/Axis/AxisRawData.cs
+++ b/AxSlime/Axis/AxisRawData.cs
@@ -2,7 +2,7 @@ using System.Numerics;
 
 namespace AxSlime.Axis
 {
-    public enum NodeBinding
+    public enum NodeBinding : byte
     {
         RightThigh,
         RightCalf,

--- a/AxSlime/Config/AxSlimeConfig.cs
+++ b/AxSlime/Config/AxSlimeConfig.cs
@@ -8,13 +8,29 @@ namespace AxSlime.Config
         public static readonly AxSlimeConfig Default = new();
 
         [JsonPropertyName("config_version")]
-        public int ConfigVersion { get; set; } = 0;
+        public int ConfigVersion { get; set; } = 1;
 
         [JsonPropertyName("slimevr_endpoint")]
         public string SlimeVrEndPointStr { get; set; } = "127.0.0.1:6969";
 
+        [JsonPropertyName("osc_enabled")]
+        public bool OscEnabled { get; set; } = false;
+
+        [JsonPropertyName("osc_receive_endpoint")]
+        public string OscReceiveEndPointStr { get; set; } = "127.0.0.1:9001";
+
+        [JsonPropertyName("haptic_vibration_intensity")]
+        public float HapticVibrationIntensity { get; set; } = 1f;
+
+        [JsonPropertyName("haptic_vibration_duration_s")]
+        public float HapticVibrationDurationS { get; set; } = 1f;
+
+        // Ease of use utilities
         [JsonIgnore]
         public IPEndPoint SlimeVrEndPoint => IPEndPoint.Parse(SlimeVrEndPointStr);
+
+        [JsonIgnore]
+        public IPEndPoint OscReceiveEndPoint => IPEndPoint.Parse(OscReceiveEndPointStr);
     }
 
     [JsonSerializable(typeof(AxSlimeConfig))]

--- a/AxSlime/Config/AxSlimeConfig.cs
+++ b/AxSlime/Config/AxSlimeConfig.cs
@@ -19,19 +19,10 @@ namespace AxSlime.Config
         [JsonPropertyName("osc_receive_endpoint")]
         public string OscReceiveEndPointStr { get; set; } = "127.0.0.1:9001";
 
-        [JsonPropertyName("haptic_vibration_intensity")]
-        public float HapticVibrationIntensity { get; set; } = 1f;
+        [JsonPropertyName("haptic_vibration")]
+        public HapticsConfig Haptics { get; set; } = new();
 
-        [JsonPropertyName("haptic_vibration_duration_s")]
-        public float HapticVibrationDurationS { get; set; } = 1f;
-
-        [JsonPropertyName("enable_axhaptics_support")]
-        public bool EnableAxHapticsSupport { get; set; } = true;
-
-        [JsonPropertyName("enable_bhaptics_support")]
-        public bool EnableBHapticsSupport { get; set; } = true;
-
-        // Ease of use utilities
+        // Utilities
 
         [JsonIgnore]
         public IPEndPoint SlimeVrEndPoint => IPEndPoint.Parse(SlimeVrEndPointStr);

--- a/AxSlime/Config/AxSlimeConfig.cs
+++ b/AxSlime/Config/AxSlimeConfig.cs
@@ -25,10 +25,14 @@ namespace AxSlime.Config
         [JsonPropertyName("haptic_vibration_duration_s")]
         public float HapticVibrationDurationS { get; set; } = 1f;
 
+        [JsonPropertyName("enable_axhaptics_support")]
+        public bool EnableAxHapticsSupport { get; set; } = true;
+
         [JsonPropertyName("enable_bhaptics_support")]
         public bool EnableBHapticsSupport { get; set; } = true;
 
         // Ease of use utilities
+
         [JsonIgnore]
         public IPEndPoint SlimeVrEndPoint => IPEndPoint.Parse(SlimeVrEndPointStr);
 

--- a/AxSlime/Config/AxSlimeConfig.cs
+++ b/AxSlime/Config/AxSlimeConfig.cs
@@ -25,6 +25,9 @@ namespace AxSlime.Config
         [JsonPropertyName("haptic_vibration_duration_s")]
         public float HapticVibrationDurationS { get; set; } = 1f;
 
+        [JsonPropertyName("enable_bhaptics_support")]
+        public bool EnableBHapticsSupport { get; set; } = true;
+
         // Ease of use utilities
         [JsonIgnore]
         public IPEndPoint SlimeVrEndPoint => IPEndPoint.Parse(SlimeVrEndPointStr);

--- a/AxSlime/Config/HapticsConfig.cs
+++ b/AxSlime/Config/HapticsConfig.cs
@@ -30,8 +30,8 @@ namespace AxSlime.Config
         [JsonPropertyName("proximity_duration_s")]
         public float ProxDurationS { get; set; } = 0.1f;
 
-        [JsonPropertyName("nonlinear_proximity")]
-        public bool NonlinearProx { get; set; } = true;
+        [JsonPropertyName("linear_proximity")]
+        public bool LinearProx { get; set; } = false;
 
         [JsonPropertyName("enable_axhaptics_support")]
         public bool EnableAxHaptics { get; set; } = true;
@@ -43,5 +43,15 @@ namespace AxSlime.Config
 
         [JsonIgnore]
         public float ProxIntensityRange => ProxMaxIntensity - ProxMinIntensity;
+
+        public float CalcIntensity(float proximity)
+        {
+            var scaledProx = LinearProx ? proximity : proximity * proximity;
+            return float.Clamp(
+                ProxMinIntensity + (scaledProx * ProxIntensityRange),
+                ProxMinIntensity,
+                ProxMaxIntensity
+            );
+        }
     }
 }

--- a/AxSlime/Config/HapticsConfig.cs
+++ b/AxSlime/Config/HapticsConfig.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace AxSlime.Config
+{
+    public record class HapticsConfig
+    {
+        public static readonly HapticsConfig Default = new();
+
+        [JsonPropertyName("enable_touch")]
+        public bool EnableTouch { get; set; } = true;
+
+        [JsonPropertyName("touch_intensity")]
+        public float TouchIntensity { get; set; } = 1f;
+
+        [JsonPropertyName("touch_duration_s")]
+        public float TouchDurationS { get; set; } = 1f;
+
+        [JsonPropertyName("enable_proximity")]
+        public bool EnableProx { get; set; } = true;
+
+        [JsonPropertyName("proximity_threshold")]
+        public float ProxThreshold { get; set; } = 0f;
+
+        [JsonPropertyName("proximity_min_intensity")]
+        public float ProxMinIntensity { get; set; } = 0.25f;
+
+        [JsonPropertyName("proximity_max_intensity")]
+        public float ProxMaxIntensity { get; set; } = 1f;
+
+        [JsonPropertyName("proximity_duration_s")]
+        public float ProxDurationS { get; set; } = 0.1f;
+
+        [JsonPropertyName("nonlinear_proximity")]
+        public bool NonlinearProx { get; set; } = true;
+
+        [JsonPropertyName("enable_axhaptics_support")]
+        public bool EnableAxHaptics { get; set; } = true;
+
+        [JsonPropertyName("enable_bhaptics_support")]
+        public bool EnableBHaptics { get; set; } = true;
+
+        // Utilities
+
+        [JsonIgnore]
+        public float ProxIntensityRange => ProxMaxIntensity - ProxMinIntensity;
+    }
+}

--- a/AxSlime/Osc/AxHaptics.cs
+++ b/AxSlime/Osc/AxHaptics.cs
@@ -1,0 +1,49 @@
+using AxSlime.Axis;
+using LucHeart.CoreOSC;
+
+namespace AxSlime.Osc
+{
+    public class AxHaptics : HapticsSource
+    {
+        public static readonly string AxHapticsPrefix = "VRCOSC/AXHaptics/";
+        public static readonly string LegacyPrefix = "Is";
+        public static readonly string LegacySuffix = "HapticActive";
+        public static readonly string BinaryPrefix = "Touched";
+        public static readonly string AnalogPrefix = "Proximity";
+
+        private static readonly Dictionary<string, NodeBinding> _nameToNode =
+            Enum.GetValues<NodeBinding>().ToDictionary(v => Enum.GetName(v)!);
+
+        public HapticEvent[] ComputeHaptics(string parameter, OscMessage message)
+        {
+            var axHaptics = parameter[AxHapticsPrefix.Length..];
+            if (axHaptics.StartsWith(LegacyPrefix) && axHaptics.EndsWith(LegacySuffix))
+            {
+                if (
+                    _nameToNode.TryGetValue(
+                        axHaptics[LegacyPrefix.Length..(axHaptics.Length - LegacySuffix.Length)],
+                        out var nodeVal
+                    )
+                )
+                    return [new HapticEvent(nodeVal)];
+            }
+            else if (axHaptics.StartsWith(BinaryPrefix))
+            {
+                if (_nameToNode.TryGetValue(axHaptics[BinaryPrefix.Length..], out var nodeVal))
+                    return [new HapticEvent(nodeVal)];
+            }
+            else if (axHaptics.StartsWith(AnalogPrefix))
+            {
+                if (_nameToNode.TryGetValue(axHaptics[AnalogPrefix.Length..], out var nodeVal))
+                    return [new HapticEvent(nodeVal)];
+            }
+
+            return [];
+        }
+
+        public bool IsSource(string parameter, OscMessage message)
+        {
+            return parameter.StartsWith(AxHapticsPrefix);
+        }
+    }
+}

--- a/AxSlime/Osc/AxHaptics.cs
+++ b/AxSlime/Osc/AxHaptics.cs
@@ -6,8 +6,6 @@ namespace AxSlime.Osc
     public class AxHaptics : HapticsSource
     {
         public static readonly string AxHapticsPrefix = "VRCOSC/AXHaptics/";
-        public static readonly string LegacyPrefix = "Is";
-        public static readonly string LegacySuffix = "HapticActive";
         public static readonly string BinaryPrefix = "Touched";
         public static readonly string AnalogPrefix = "Proximity";
 
@@ -17,17 +15,7 @@ namespace AxSlime.Osc
         public HapticEvent[] ComputeHaptics(string parameter, OscMessage message)
         {
             var axHaptics = parameter[AxHapticsPrefix.Length..];
-            if (axHaptics.StartsWith(LegacyPrefix) && axHaptics.EndsWith(LegacySuffix))
-            {
-                if (
-                    _nameToNode.TryGetValue(
-                        axHaptics[LegacyPrefix.Length..(axHaptics.Length - LegacySuffix.Length)],
-                        out var nodeVal
-                    )
-                )
-                    return [new HapticEvent(nodeVal)];
-            }
-            else if (axHaptics.StartsWith(BinaryPrefix))
+            if (axHaptics.StartsWith(BinaryPrefix))
             {
                 if (_nameToNode.TryGetValue(axHaptics[BinaryPrefix.Length..], out var nodeVal))
                     return [new HapticEvent(nodeVal)];

--- a/AxSlime/Osc/AxHaptics.cs
+++ b/AxSlime/Osc/AxHaptics.cs
@@ -38,15 +38,7 @@ namespace AxSlime.Osc
                 if (proximity <= _config.Haptics.ProxThreshold)
                     return [];
 
-                proximity = float.Clamp(proximity, 0f, 1f);
-                var scaledProx = _config.Haptics.NonlinearProx ? proximity * proximity : proximity;
-
-                var intensity = float.Clamp(
-                    _config.Haptics.ProxMinIntensity
-                        + (scaledProx * _config.Haptics.ProxIntensityRange),
-                    _config.Haptics.ProxMinIntensity,
-                    _config.Haptics.ProxMaxIntensity
-                );
+                var intensity = _config.Haptics.CalcIntensity(proximity);
                 if (
                     intensity > 0f
                     && _nameToNode.TryGetValue(axHaptics[AnalogPrefix.Length..], out var nodeVal)

--- a/AxSlime/Osc/AxHaptics.cs
+++ b/AxSlime/Osc/AxHaptics.cs
@@ -1,4 +1,5 @@
 using AxSlime.Axis;
+using AxSlime.Config;
 using LucHeart.CoreOSC;
 
 namespace AxSlime.Osc
@@ -12,18 +13,45 @@ namespace AxSlime.Osc
         private static readonly Dictionary<string, NodeBinding> _nameToNode =
             Enum.GetValues<NodeBinding>().ToDictionary(v => Enum.GetName(v)!);
 
+        private readonly AxSlimeConfig _config;
+
+        public AxHaptics(AxSlimeConfig config)
+        {
+            _config = config;
+        }
+
         public HapticEvent[] ComputeHaptics(string parameter, OscMessage message)
         {
             var axHaptics = parameter[AxHapticsPrefix.Length..];
-            if (axHaptics.StartsWith(BinaryPrefix))
+            if (_config.Haptics.EnableTouch && axHaptics.StartsWith(BinaryPrefix))
             {
+                var trigger = message.Arguments[0] as bool?;
+                if (trigger != true)
+                    return [];
+
                 if (_nameToNode.TryGetValue(axHaptics[BinaryPrefix.Length..], out var nodeVal))
                     return [new HapticEvent(nodeVal)];
             }
-            else if (axHaptics.StartsWith(AnalogPrefix))
+            else if (_config.Haptics.EnableProx && axHaptics.StartsWith(AnalogPrefix))
             {
-                if (_nameToNode.TryGetValue(axHaptics[AnalogPrefix.Length..], out var nodeVal))
-                    return [new HapticEvent(nodeVal)];
+                var proximity = message.Arguments[0] as float? ?? -1f;
+                if (proximity <= _config.Haptics.ProxThreshold)
+                    return [];
+
+                proximity = float.Clamp(proximity, 0f, 1f);
+                var scaledProx = _config.Haptics.NonlinearProx ? proximity * proximity : proximity;
+
+                var intensity = float.Clamp(
+                    _config.Haptics.ProxMinIntensity
+                        + (scaledProx * _config.Haptics.ProxIntensityRange),
+                    _config.Haptics.ProxMinIntensity,
+                    _config.Haptics.ProxMaxIntensity
+                );
+                if (
+                    intensity > 0f
+                    && _nameToNode.TryGetValue(axHaptics[AnalogPrefix.Length..], out var nodeVal)
+                )
+                    return [new HapticEvent(nodeVal, intensity, _config.Haptics.ProxDurationS)];
             }
 
             return [];
@@ -31,7 +59,7 @@ namespace AxSlime.Osc
 
         public bool IsSource(string parameter, OscMessage message)
         {
-            return parameter.StartsWith(AxHapticsPrefix);
+            return _config.Haptics.EnableAxHaptics && parameter.StartsWith(AxHapticsPrefix);
         }
     }
 }

--- a/AxSlime/Osc/HapticEvent.cs
+++ b/AxSlime/Osc/HapticEvent.cs
@@ -1,0 +1,18 @@
+using AxSlime.Axis;
+
+namespace AxSlime.Osc
+{
+    public readonly record struct HapticEvent
+    {
+        public readonly NodeBinding Node;
+        public readonly float? Intensity;
+        public readonly float? Duration;
+
+        public HapticEvent(NodeBinding node, float? intensity = null, float? duration = null)
+        {
+            Node = node;
+            Intensity = intensity;
+            Duration = duration;
+        }
+    }
+}

--- a/AxSlime/Osc/HapticsSource.cs
+++ b/AxSlime/Osc/HapticsSource.cs
@@ -1,0 +1,10 @@
+using LucHeart.CoreOSC;
+
+namespace AxSlime.Osc
+{
+    public interface HapticsSource
+    {
+        public HapticEvent[] ComputeHaptics(string parameter, OscMessage message);
+        public bool IsSource(string parameter, OscMessage message);
+    }
+}

--- a/AxSlime/Osc/OscHandler.cs
+++ b/AxSlime/Osc/OscHandler.cs
@@ -8,6 +8,8 @@ namespace AxSlime.Osc
 {
     public class OscHandler : IDisposable
     {
+        public static readonly string AvatarParamPrefix = "/avatar/parameters/";
+
         private readonly AxisCommander _axisCommander;
         private readonly float _intensity;
         private readonly float _durationSeconds;
@@ -99,7 +101,10 @@ namespace AxSlime.Osc
 
         private static NodeBinding? GetNodeFromAddress(string address)
         {
-            switch (address)
+            if (address.Length <= AvatarParamPrefix.Length)
+                return null;
+
+            switch (address[AvatarParamPrefix.Length..])
             {
                 case "VRCOSC/AXHaptics/IsRightThighHapticActive":
                     return NodeBinding.RightThigh;

--- a/AxSlime/Osc/OscHandler.cs
+++ b/AxSlime/Osc/OscHandler.cs
@@ -8,6 +8,8 @@ namespace AxSlime.Osc
 {
     public class OscHandler : IDisposable
     {
+        public static readonly string BundleAddress = "#bundle\0";
+        public static readonly byte[] BundleAddressBytes = Encoding.ASCII.GetBytes(BundleAddress);
         public static readonly string AvatarParamPrefix = "/avatar/parameters/";
         public static readonly string bHapticsPrefix = "bHapticsOSC_";
 
@@ -42,7 +44,7 @@ namespace AxSlime.Osc
 
         private static bool IsBundle(ReadOnlySpan<byte> buffer)
         {
-            return buffer.Length > 16 && Encoding.ASCII.GetString(buffer[..8]) == "#bundle\0";
+            return buffer.Length > 16 && buffer[..8].SequenceEqual(BundleAddressBytes);
         }
 
         private async Task OscReceiveTask(CancellationToken cancelToken = default)

--- a/AxSlime/Osc/OscHandler.cs
+++ b/AxSlime/Osc/OscHandler.cs
@@ -19,18 +19,24 @@ namespace AxSlime.Osc
         private readonly CancellationTokenSource _cancelTokenSource = new();
         private readonly Task _oscReceiveTask;
 
+        private readonly bool _useBHaptics;
+
         public OscHandler(
             AxisCommander axisCommander,
             float intensity = 1f,
             float durationSeconds = 1f,
-            IPEndPoint? ipEndPoint = null
+            IPEndPoint? ipEndPoint = null,
+            bool useBHaptics = true
         )
         {
             _axisCommander = axisCommander;
             _intensity = intensity;
             _durationSeconds = durationSeconds;
+
             _oscClient = new UdpClient(ipEndPoint ?? new IPEndPoint(IPAddress.Loopback, 9001));
             _oscReceiveTask = OscReceiveTask(_cancelTokenSource.Token);
+
+            _useBHaptics = useBHaptics;
         }
 
         private static bool IsBundle(ReadOnlySpan<byte> buffer)
@@ -105,7 +111,7 @@ namespace AxSlime.Osc
             }
         }
 
-        private static NodeBinding[]? GetNodesFromAddress(string address)
+        private NodeBinding[]? GetNodesFromAddress(string address)
         {
             if (address.Length <= AvatarParamPrefix.Length)
                 return null;
@@ -133,7 +139,7 @@ namespace AxSlime.Osc
                     return [NodeBinding.Chest];
             }
 
-            if (param.StartsWith(bHapticsPrefix))
+            if (_useBHaptics && param.StartsWith(bHapticsPrefix))
             {
                 var bHaptics = param[bHapticsPrefix.Length..];
                 if (bHaptics.StartsWith("Vest_Front") || bHaptics.StartsWith("Vest_Back"))

--- a/AxSlime/Osc/OscHandler.cs
+++ b/AxSlime/Osc/OscHandler.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AxSlime.Axis;
+using LucHeart.CoreOSC;
+
+namespace AxSlime.Osc
+{
+    public class OscHandler : IDisposable
+    {
+        private readonly AxisCommander _axisCommander;
+        private readonly float _intensity;
+        private readonly float _durationSeconds;
+
+        private readonly UdpClient _oscClient;
+        private readonly CancellationTokenSource _cancelTokenSource = new();
+        private readonly Task _oscReceiveTask;
+
+        public OscHandler(
+            AxisCommander axisCommander,
+            float intensity = 1f,
+            float durationSeconds = 1f,
+            IPEndPoint? ipEndPoint = null
+        )
+        {
+            _axisCommander = axisCommander;
+            _intensity = intensity;
+            _durationSeconds = durationSeconds;
+            _oscClient = new UdpClient(ipEndPoint ?? new IPEndPoint(IPAddress.Loopback, 9001));
+            _oscReceiveTask = OscReceiveTask(_cancelTokenSource.Token);
+        }
+
+        private static bool IsBundle(ReadOnlySpan<byte> buffer)
+        {
+            return buffer.Length > 16 && Encoding.ASCII.GetString(buffer[..8]) == "#bundle\0";
+        }
+
+        private async Task OscReceiveTask(CancellationToken cancelToken = default)
+        {
+            while (!cancelToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var packet = await _oscClient.ReceiveAsync(cancelToken);
+                    if (IsBundle(packet.Buffer))
+                    {
+                        var bundle = OscBundle.ParseBundle(packet.Buffer);
+                        if (bundle.Timestamp > DateTime.Now)
+                        {
+                            // Wait for the specified timestamp
+                            _ = Task.Run(
+                                async () =>
+                                {
+                                    await Task.Delay(bundle.Timestamp - DateTime.Now, cancelToken);
+                                    OnOscBundle(bundle);
+                                },
+                                cancelToken
+                            );
+                        }
+                        else
+                        {
+                            OnOscBundle(bundle);
+                        }
+                    }
+                    else
+                    {
+                        OnOscMessage(OscMessage.ParseMessage(packet.Buffer));
+                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine(e);
+                }
+            }
+        }
+
+        private void OnOscBundle(OscBundle bundle)
+        {
+            foreach (var message in bundle.Messages)
+            {
+                OnOscMessage(message);
+            }
+        }
+
+        private void OnOscMessage(OscMessage message)
+        {
+            if (message.Arguments.Length <= 0)
+                return;
+
+            var node = GetNodeFromAddress(message.Address);
+            if (node == null)
+                return;
+
+            var trigger = (bool?)message.Arguments[0] ?? false;
+            if (trigger)
+                _axisCommander.SetNodeVibration((byte)node, _intensity, _durationSeconds);
+        }
+
+        private static NodeBinding? GetNodeFromAddress(string address)
+        {
+            switch (address)
+            {
+                case "VRCOSC/AXHaptics/IsRightThighHapticActive":
+                    return NodeBinding.RightThigh;
+                case "VRCOSC/AXHaptics/IsRightCalfHapticActive":
+                    return NodeBinding.RightCalf;
+                case "VRCOSC/AXHaptics/IsLeftThighHapticActive":
+                    return NodeBinding.LeftThigh;
+                case "VRCOSC/AXHaptics/IsLeftCalfHapticActive":
+                    return NodeBinding.LeftCalf;
+                case "VRCOSC/AXHaptics/IsRightUpperArmHapticActive":
+                    return NodeBinding.RightUpperArm;
+                case "VRCOSC/AXHaptics/IsRightForearmHapticActive":
+                    return NodeBinding.RightForeArm;
+                case "VRCOSC/AXHaptics/IsLeftUpperArmHapticActive":
+                    return NodeBinding.LeftUpperArm;
+                case "VRCOSC/AXHaptics/IsLeftForearmHapticActive":
+                    return NodeBinding.LeftForeArm;
+                case "VRCOSC/AXHaptics/IsChestHapticActive":
+                    return NodeBinding.Chest;
+                default:
+                    return null;
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancelTokenSource.Cancel();
+            _oscReceiveTask.Wait();
+            _cancelTokenSource.Dispose();
+            _oscClient.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/AxSlime/Osc/bHaptics.cs
+++ b/AxSlime/Osc/bHaptics.cs
@@ -1,0 +1,51 @@
+using AxSlime.Axis;
+using LucHeart.CoreOSC;
+
+namespace AxSlime.Osc
+{
+    public class bHaptics : HapticsSource
+    {
+        public static readonly string bHapticsPrefix = "bHapticsOSC_";
+
+        private static readonly Dictionary<string, NodeBinding[]> _mappings =
+            new()
+            {
+                { "Vest_Front", [NodeBinding.Chest, NodeBinding.Hips] },
+                { "Vest_Back", [NodeBinding.Chest, NodeBinding.Hips] },
+                { "Arm_Left", [NodeBinding.LeftUpperArm, NodeBinding.LeftForeArm] },
+                { "Arm_Right", [NodeBinding.RightUpperArm, NodeBinding.RightForeArm] },
+                {
+                    "Foot_Left",
+                    [NodeBinding.LeftFoot, NodeBinding.LeftCalf, NodeBinding.LeftThigh]
+                },
+                {
+                    "Foot_Right",
+                    [NodeBinding.RightFoot, NodeBinding.RightCalf, NodeBinding.RightThigh]
+                },
+                { "Hand_Left", [NodeBinding.LeftHand] },
+                { "Hand_Right", [NodeBinding.RightHand] },
+                { "Head", [NodeBinding.Head] },
+            };
+
+        private static readonly Dictionary<string, HapticEvent[]> _eventMap = _mappings
+            .Select(m => (m.Key, m.Value.Select(n => new HapticEvent(n)).ToArray()))
+            .ToDictionary();
+
+        public HapticEvent[] ComputeHaptics(string parameter, OscMessage message)
+        {
+            var bHaptics = parameter[bHapticsPrefix.Length..];
+            foreach (var binding in _eventMap)
+            {
+                if (bHaptics.StartsWith(binding.Key))
+                    return binding.Value;
+            }
+
+            return [];
+        }
+
+        public bool IsSource(string parameter, OscMessage message)
+        {
+            return parameter.StartsWith(bHapticsPrefix);
+        }
+    }
+}

--- a/AxSlime/Osc/bHaptics.cs
+++ b/AxSlime/Osc/bHaptics.cs
@@ -1,4 +1,5 @@
 using AxSlime.Axis;
+using AxSlime.Config;
 using LucHeart.CoreOSC;
 
 namespace AxSlime.Osc
@@ -31,8 +32,22 @@ namespace AxSlime.Osc
             .Select(m => (m.Key, m.Value.Select(n => new HapticEvent(n)).ToArray()))
             .ToDictionary();
 
+        private readonly AxSlimeConfig _config;
+
+        public bHaptics(AxSlimeConfig config)
+        {
+            _config = config;
+        }
+
         public HapticEvent[] ComputeHaptics(string parameter, OscMessage message)
         {
+            if (!_config.Haptics.EnableTouch)
+                return [];
+
+            var trigger = message.Arguments[0] as bool?;
+            if (trigger != true)
+                return [];
+
             var bHaptics = parameter[bHapticsPrefix.Length..];
             foreach (var binding in _eventMap)
             {
@@ -45,7 +60,7 @@ namespace AxSlime.Osc
 
         public bool IsSource(string parameter, OscMessage message)
         {
-            return parameter.StartsWith(bHapticsPrefix);
+            return _config.Haptics.EnableBHaptics && parameter.StartsWith(bHapticsPrefix);
         }
     }
 }

--- a/AxSlime/Program.cs
+++ b/AxSlime/Program.cs
@@ -44,12 +44,14 @@ try
 
     if (config.OscEnabled)
     {
+        var oscEndPoint = config.OscReceiveEndPoint;
         oscHandler = new OscHandler(
             axisSocket.AxisRuntimeCommander,
             config.HapticVibrationIntensity,
             config.HapticVibrationDurationS,
-            config.OscReceiveEndPoint
+            oscEndPoint
         );
+        Console.WriteLine($"Started OSC receiver on {oscEndPoint}.");
     }
 
     Console.WriteLine("AXIS receiver is running, press any key to stop the receiver.");

--- a/AxSlime/Program.cs
+++ b/AxSlime/Program.cs
@@ -49,7 +49,8 @@ try
             axisSocket.AxisRuntimeCommander,
             config.HapticVibrationIntensity,
             config.HapticVibrationDurationS,
-            oscEndPoint
+            oscEndPoint,
+            config.EnableBHapticsSupport
         );
         Console.WriteLine($"Started OSC receiver on {oscEndPoint}.");
     }

--- a/AxSlime/Program.cs
+++ b/AxSlime/Program.cs
@@ -44,16 +44,8 @@ try
 
     if (config.OscEnabled)
     {
-        var oscEndPoint = config.OscReceiveEndPoint;
-        oscHandler = new OscHandler(
-            axisSocket.AxisRuntimeCommander,
-            config.HapticVibrationIntensity,
-            config.HapticVibrationDurationS,
-            oscEndPoint,
-            config.EnableAxHapticsSupport,
-            config.EnableBHapticsSupport
-        );
-        Console.WriteLine($"Started OSC receiver on {oscEndPoint}.");
+        oscHandler = new OscHandler(config, axisSocket.AxisRuntimeCommander);
+        Console.WriteLine($"Started OSC receiver on {config.OscReceiveEndPoint}.");
     }
 
     Console.WriteLine("AXIS receiver is running, press any key to stop the receiver.");

--- a/AxSlime/Program.cs
+++ b/AxSlime/Program.cs
@@ -2,8 +2,10 @@ using AxSlime;
 using AxSlime.Axis;
 using AxSlime.Bridge;
 using AxSlime.Config;
+using AxSlime.Osc;
 
 AxSlimeConfig config;
+OscHandler? oscHandler = null;
 BridgeController? bridge = null;
 void OnTrackerData(object? sender, AxisOutputData data)
 {
@@ -40,6 +42,16 @@ try
     axisSocket.OnAxisData += OnTrackerData;
     axisSocket.Start();
 
+    if (config.OscEnabled)
+    {
+        oscHandler = new OscHandler(
+            axisSocket.AxisRuntimeCommander,
+            config.HapticVibrationIntensity,
+            config.HapticVibrationDurationS,
+            config.OscReceiveEndPoint
+        );
+    }
+
     Console.WriteLine("AXIS receiver is running, press any key to stop the receiver.");
     Console.ReadKey();
 }
@@ -49,6 +61,7 @@ catch (Exception e)
 }
 finally
 {
+    oscHandler?.Dispose();
     bridge?.Dispose();
 }
 

--- a/AxSlime/Program.cs
+++ b/AxSlime/Program.cs
@@ -50,6 +50,7 @@ try
             config.HapticVibrationIntensity,
             config.HapticVibrationDurationS,
             oscEndPoint,
+            config.EnableAxHapticsSupport,
             config.EnableBHapticsSupport
         );
         Console.WriteLine($"Started OSC receiver on {oscEndPoint}.");

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ A bridge to make AXIS trackers work with SlimeVR.
   - <https://github.com/SlimeVR/>
   - <https://github.com/SlimeVR/SlimeVR-Server>
   - <https://github.com/SlimeVR/SlimeVR-Tracker-ESP>
+- CoreOSC
+  - <https://github.com/LucHeart/CoreOSC-UTF8-ASYNC>
+- AxHaptics
+  - <https://github.com/TahvoDev/AxHaptics>

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -16,3 +16,27 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ---------------------------------------------------------------
+https://github.com/LucHeart/CoreOSC-UTF8-ASYNC
+
+MIT License
+
+Copyright (c) 2023 LucHeart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+---------------------------------------------------------------


### PR DESCRIPTION
Implements basic support for [AXHaptics](https://github.com/TahvoDev/AxHaptics) and [bHaptics](https://github.com/bhaptics/VRChatOSC) OSC implementations. This is currently untested with the hardware, but appears to function basically with VRChat. OSC support is disabled by default to prevent accidental interference with other software.